### PR TITLE
Replace perfsonar-toolkit-compat-database package

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,10 @@
 perfsonar-bundles (4.3.0~a1.0) perfsonar-4.3-snapshot; urgency=low
 
   * New upstream version.
+  * Replacing perfsonar-toolkit-compat-database dependency with
+    perfsonar-toolkit-esmond-utils
 
- -- Antoine Delvaux <antoine.delvaux@man.poznan.pl>  Sun, 25 Aug 2019 18:27:34 +0000
+ -- Antoine Delvaux <antoine.delvaux@man.poznan.pl>  Thu, 06 Aug 2020 14:56:43 +0000
 
 perfsonar-bundles (4.2.3) perfsonar-4.2; urgency=low
 

--- a/debian/control
+++ b/debian/control
@@ -46,7 +46,7 @@ Description: perfSONAR testpoint metapackage
 Package: perfsonar-core
 Architecture: all
 Depends: perfsonar-testpoint, esmond (>= 2.1),
- perfsonar-toolkit-compat-database, ${misc:Depends}
+ perfsonar-toolkit-esmond-utils, ${misc:Depends}
 Description: perfSONAR core metapackage
  perfSONAR combines a number of measurement tools and services.
  .

--- a/perfsonar.spec
+++ b/perfsonar.spec
@@ -71,11 +71,10 @@ Perform regularly scheduled perfSONAR measurements and store the results remotel
 Summary:                perfSONAR scheduled testing and storage tools
 Group:                  Applications/Communications
 Requires:               perfsonar-testpoint
-Requires:               perfsonar-toolkit-compat-database
+Requires:               perfsonar-toolkit-esmond-utils
 Requires:               esmond >= 2.1
-Requires:               esmond-database-postgresql95
 Requires:               perfsonar-toolkit-install
-Requires(post):         perfsonar-toolkit-compat-database
+Requires(post):         perfsonar-toolkit-esmond-utils
 Obsoletes:              perfSONAR-Bundles-Core
 Provides:               perfSONAR-Bundles-Core
 
@@ -91,10 +90,9 @@ Requires:       libperfsonar-perl
 Requires:       perfsonar-lsregistrationdaemon
 Requires:       perfsonar-psconfig-maddash
 Requires:       perfsonar-psconfig-publisher
-Requires:       perfsonar-toolkit-compat-database
+Requires:       perfsonar-toolkit-esmond-utils
 Requires:       maddash
 Requires:       esmond >= 2.1
-Requires:       esmond-database-postgresql95
 Obsoletes:      perfSONAR-Bundles-CentralManagement
 Provides:       perfSONAR-Bundles-CentralManagement
 


### PR DESCRIPTION
This relates (and depends on) https://github.com/perfsonar/toolkit/pull/405 

Replaces the perfsonar-toolkit-compat-databas dependencies with the new perfsonar-toolkit-esmond-utils package from the pull request above. Also removes the postgresql95 references 